### PR TITLE
Update for shared workflows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -124,7 +124,7 @@ If you have Ruby 2.x or want a specific version of Puppet,
 you must set an environment variable such as:
 
 ```sh
-export PUPPET_VERSION="~> 5.5.6"
+export PUPPET_GEM_VERSION="~> 5.5.6"
 ```
 
 You can install all needed gems for spec tests into the modules directory by
@@ -232,17 +232,16 @@ simple tests against it after applying the module. You can run this
 with:
 
 ```sh
-BEAKER_setfile=debian10-x64 bundle exec rake beaker
+BEAKER_setfile=debian11-64 bundle exec rake beaker
 ```
 
 You can replace the string `debian10` with any common operating system.
 The following strings are known to work:
 
-* ubuntu1604
 * ubuntu1804
 * ubuntu2004
-* debian9
 * debian10
+* debian11
 * centos7
 * centos8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: CI
 on: pull_request
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /opt/puppet
 # https://github.com/puppetlabs/puppet/blob/06ad255754a38f22fb3a22c7c4f1e2ce453d01cb/lib/puppet/provider/service/runit.rb#L39
 RUN mkdir -p /etc/sv
 
-ARG PUPPET_VERSION="~> 6.0"
+ARG PUPPET_GEM_VERSION="~> 6.0"
 ARG PARALLEL_TEST_PROCESSORS=4
 
 # Cache gems

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_VERSION'] || '>= 6.0'
+puppetversion = ENV['PUPPET_GEM_VERSION'] || '>= 6.0'
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby


### PR DESCRIPTION
gha-puppet 1.0.0 uses `PUPPET_GEM_VERSION`. This reflects that change.