### PR TITLE
Show rspec-github integration in puppetlabs_spec_helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,6 @@ gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 puppetversion = ENV['PUPPET_VERSION'] || '>= 6.0'
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
+gem 'puppetlabs_spec_helper', github: 'ekohl/puppetlabs_spec_helper', branch: 'add-rspec-github-integration'
+
 # vim: syntax=ruby

--- a/spec/classes/example_spec.rb
+++ b/spec/classes/example_spec.rb
@@ -7,7 +7,7 @@ describe 'example' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to compile.with_all_deps }
+      it { is_expected.not_to compile.with_all_deps }
       it { is_expected.to contain_file('/tmp/puppet-example').with_content('Hello World!') }
     end
   end


### PR DESCRIPTION
This is to show that integration in puppetlabs_spec_helper works. Once https://github.com/puppetlabs/puppetlabs_spec_helper/pull/353 is merged, this is redundant.