### PR TITLE
prepare .sync.yml to test msync_config changes

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,6 @@
 ---
 spec/spec_helper_acceptance.rb:
   unmanaged: false
+
+.github/workflows/ci.yml:
+  rubocop: true


### PR DESCRIPTION
Adding input rubocop:true ( the deafult ) to verify that https://github.com/voxpupuli/modulesync_config/pull/888 still work with existing sync files.
