### PR TITLE
Archlinux: Fix typo in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "ArchLinux"
+      "operatingsystem": "Archlinux"
     },
     {
       "operatingsystem": "CentOS",


### PR DESCRIPTION
during https://github.com/voxpupuli/puppet-example/pull/70 I noticed that we've a typo in our metadata.json (we should probably also update puppet_metadata to recognize `ArchLinux`).