### PR TITLE
prepare release action: Make version input optional

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       version:
         description: 'Module version to be released. Must be a valid semver string without leading v. (1.2.3)'
-        required: true
+        required: false
 
 jobs:
   release_prep:


### PR DESCRIPTION
The idea is to run the action twice. The first time without a version input. It will generate a CHANGELOG.md update and raises a PR. Then the changelog can be reviewed. based on the categories, the correct new version can be determined and the action can be executed again.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
