### PR TITLE
beaker: test new OpenVox packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem 'voxpupuli-test', '~> 9.0',   :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
-  gem 'puppet_metadata', '~> 4.0',  :require => false
+  gem 'puppet_metadata', '~>5.0',  :require => false
 end
 
 group :development do
@@ -16,7 +16,8 @@ group :development do
 end
 
 group :system_tests do
-  gem 'voxpupuli-acceptance', '~> 3.0',  :require => false
+  gem 'beaker_puppet_helpers', github: 'bastelfreak/beaker_puppet_helpers', branch: 'api'
+  gem 'voxpupuli-acceptance', github: 'bastelfreak/voxpupuli-acceptance', branch: 'openvox'
 end
 
 group :release do

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "puppet",
       "version_requirement": ">= 7.0.0 < 9.0.0"
+    },
+    {
+      "name": "openvox",
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This is a test for the new openvox packages. So far the following changes were required:
* https://github.com/voxpupuli/beaker_puppet_helpers/pull/56
* https://github.com/voxpupuli/puppet_metadata/pull/165
* https://github.com/voxpupuli/voxpupuli-acceptance/pull/92