### PR TITLE
Remove puppet implementation support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,10 +13,6 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
-    },
-    {
       "name": "openvox",
       "version_requirement": ">= 7.0.0 < 9.0.0"
     }


### PR DESCRIPTION
We want to figure out what the forge does when metadata.json only lists openvox and not puppet anymore.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
