### PR TITLE
Replace fedora 40 with 41

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -256,7 +256,7 @@ The following strings are known to work:
 * centos9
 * almalinux8
 * almalinux9
-* fedora36
+* fedora41
 
 For more information and tips & tricks, see [voxpupuli-acceptance's documentation](https://github.com/voxpupuli/voxpupuli-acceptance#running-tests).
 

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "40"
+        "41"
       ]
     },
     {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

fedora 40 is now EOL since 2025-05-13, so we want to follow along and bump the supported version.

see: https://docs.fedoraproject.org/en-US/releases/eol/

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
none open yet